### PR TITLE
Add backend base data model, and typescript client to frontend

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -559,6 +559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +575,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1374,6 +1395,7 @@ dependencies = [
 name = "kroco6"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "serde",
  "serde_json",
  "tauri",
@@ -1674,6 +1696,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "1.5.0", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.3", features = ["dialog-message"] }
+dirs = "5.0.1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,42 +1,60 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::io::{Write, Read};
+mod models;
+mod operations;
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
+use tauri::Error;
 
-#[derive(Debug)]
-struct Script(Mutex<String>);
 
 fn main() {
-  tauri::Builder::default()
-    .manage(Script(Default::default()))
-    .invoke_handler(tauri::generate_handler![open_run_window, run_script])
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    let application_state = ApplicationState::default();
+    application_state.project_manager.initialize().expect("Failed to initialize application state");
+
+    tauri::Builder::default()
+        .manage(application_state)
+        .invoke_handler(tauri::generate_handler![open_run_window, run_script, list_projects])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 
 #[tauri::command]
-async fn open_run_window(handle: tauri::AppHandle, state: tauri::State<'_, Script>, script: String) -> Result<(), String>{
+async fn open_run_window(
+    handle: tauri::AppHandle,
+    state: tauri::State<'_, ApplicationState>,
+    script: String,
+) -> Result<(), String> {
     let run_window = tauri::WindowBuilder::new(
-      &handle,
-      "run_window", /* the unique window label */
-      tauri::WindowUrl::App("test/run".into())
-    ).inner_size(1400.0, 1000.0).build().unwrap();
+        &handle,
+        "run_window", /* the unique window label */
+        tauri::WindowUrl::App("test/run".into()),
+    )
+    .inner_size(1400.0, 1000.0)
+    .build()
+    .unwrap();
     run_window.set_title("Kroco Gator").unwrap();
 
-    let mut mtx = state.0.lock().unwrap();
-    mtx.clear();
-    mtx.push_str(script.as_str());
-    println!("{:?}", mtx);
+    let mut state_script = state.script.lock().unwrap();
+    state_script.clear();
+    state_script.push_str(script.as_str());
+    println!("{:?}", state_script);
 
     Ok(())
-
 }
 
+#[tauri::command]
+async fn list_projects(state: tauri::State<'_, ApplicationState>) -> Result<Vec<models::Project>, String> {
+    state.project_manager.list_projects()
+        .map_err(|e| e.to_string())
+}
 
 #[tauri::command]
-async fn run_script(state: tauri::State<'_, Script>) -> Result<String, String>{
+async fn run_script(state: tauri::State<'_, ApplicationState>) -> Result<String, String> {
     // let script = r#"
 
     // import http from 'k6/http';
@@ -54,30 +72,60 @@ async fn run_script(state: tauri::State<'_, Script>) -> Result<String, String>{
     // "#;
 
     let script = {
-        let mtx = state.0.lock().unwrap();
-        mtx.clone()
+        let state_script = state.script.lock().unwrap();
+        state_script.clone()
     };
 
     // TODO: make it toggable
     std::env::set_var("K6_WEB_DASHBOARD", "true");
     let mut child = Command::new("k6")
-    .arg("run")
-    .arg("-")
-    .stdin(Stdio::piped())
-    .stdout(Stdio::piped())
-    .spawn()
-    .expect("Failed to execute command");
+        .arg("run")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to execute command");
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(script.as_bytes()).expect("Failed to write script.");
+        stdin
+            .write_all(script.as_bytes())
+            .expect("Failed to write script.");
     }
 
     let mut k6_output = String::new();
     if let Some(mut stdout) = child.stdout.take() {
-        stdout.read_to_string(&mut k6_output).expect("Failed to read stdout");
+        stdout
+            .read_to_string(&mut k6_output)
+            .expect("Failed to read stdout");
     }
-    
+
     let _ = child.wait_with_output().expect("Failed to execute command");
     Ok(k6_output)
+}
 
+struct ApplicationState {
+    pub storage_path: PathBuf,
+    pub project_manager: operations::LocalProjectManager,
+
+    script: Mutex<String>
+}
+
+impl ApplicationState {
+    pub fn new() -> Self {
+        let config_dir = dirs::config_dir().expect("Failed to get config directory");
+        let storage_path = Path::new(&config_dir).join("kroco6");
+        if !&storage_path.exists() {
+            fs::create_dir(&storage_path).expect("Failed to create storage directory");
+        }
+
+        Self {
+            storage_path: storage_path.clone(),
+            project_manager: operations::LocalProjectManager::new(storage_path),
+            script: Mutex::new(String::new())
+        }
+    }
+
+    pub fn default() -> Self {
+        Self::new()
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,7 +9,6 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
-use tauri::Error;
 
 
 fn main() {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+use serde::Serialize;
+
+// TestKind represents the kind of test we are dealing with
+// (e.g. a block test, a javascript test, etc.)
+#[derive(Debug, Serialize)]
+pub enum TestKind {
+    Block,
+    Javascript,
+}
+
+// Test represents a single test that can be ran
+// either independently or as part of a suite.
+#[derive(Debug, Serialize)]
+pub struct Test {
+    kind: TestKind,
+    name: String,
+    blocks_file_path: PathBuf,
+}
+
+// A Collection represents either a single test, or
+// a suite of tests (many tests meant to be ran sequentially
+// or in parallel).
+#[derive(Debug, Serialize)]
+enum TestCollection {
+    // A single test
+    Test(Test),
+
+    // A suite of tests
+    Suite(Vec<Test>)
+}
+
+// A Project represents a collection of tests and suites
+// that can be ran.
+#[derive(Debug, Serialize)]
+pub struct Project {
+    // The test resources that are part of the project
+    pub test_collections: Vec<TestCollection>,
+
+    // The name of the Project
+    pub name: String,
+
+    // FIXME @oleiade: eventually, we want environment to be also definable
+    // at the project level (and give it precedence) but for the hackathon
+    // we start and stick with an app-wide "global" environment.
+    // environment: Environment,
+}
+
+impl Project {
+    pub fn new(name: &str) -> Self {
+        Self {
+            test_collections: vec![],
+            name: name.to_string(),
+        }
+    }
+
+    pub fn default() -> Self {
+        Self::new("default")
+    }
+}

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -15,7 +15,7 @@ pub enum TestKind {
 pub struct Test {
     kind: TestKind,
     name: String,
-    blocks_file_path: PathBuf,
+    file_path: PathBuf,
 }
 
 // A Collection represents either a single test, or
@@ -40,6 +40,8 @@ pub struct Project {
     // The name of the Project
     pub name: String,
 
+    pub description: Option<String>,
+
     // FIXME @oleiade: eventually, we want environment to be also definable
     // at the project level (and give it precedence) but for the hackathon
     // we start and stick with an app-wide "global" environment.
@@ -51,6 +53,7 @@ impl Project {
         Self {
             test_collections: vec![],
             name: name.to_string(),
+            description: None,
         }
     }
 

--- a/src-tauri/src/operations.rs
+++ b/src-tauri/src/operations.rs
@@ -1,0 +1,75 @@
+use std::{fs, io};
+use std::path;
+
+use crate::models::{Project};
+
+const PROJECTS_DIR: &str = "projects";
+
+pub(crate) struct LocalProjectManager {
+    base_path: path::PathBuf,
+}
+
+impl LocalProjectManager {
+    pub fn new(base_path: path::PathBuf) -> Self {
+        Self { base_path }
+    }
+
+    pub fn initialize(&self) -> io::Result<()> {
+        // Ensure the underlying projects directory exists
+        let projects_dir = &self.projects_dir();
+        if !projects_dir.exists() {
+            fs::create_dir(&self.projects_dir())?;
+        }
+
+        // Ensure the default project is created
+        if !projects_dir.join("default").exists() {
+            self.create("default")?;
+        }
+
+        Ok(())
+    }
+
+    // Create a new local project
+    fn create(&self, name: &str) -> io::Result<Project> {
+        let projects_dir = &self.projects_dir();
+
+        // We store projects in a directory called "projects"
+        // under the base path
+        if !projects_dir.exists() {
+            // If it doesn't already exist, create it
+            fs::create_dir(&self.projects_dir())?;
+        }
+
+        // Compute the path of the project in the "projects" directory
+        let project_path = projects_dir.join(name);
+
+        // Create the underlying directory for the project
+        fs::create_dir(project_path)?;
+
+        Ok(Project::new(name))
+    }
+
+    // List local projects
+    pub fn list_projects(&self) -> io::Result<Vec<Project>> {
+        let projects_dir = &self.projects_dir();
+        if !projects_dir.exists() {
+            return Err(io::Error::new(io::ErrorKind::NotFound, "projects directory not found"))
+        }
+
+        let mut projects = vec![];
+        for entry in fs::read_dir(projects_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                let project = Project::new(path.file_name().unwrap().to_str().unwrap());
+                projects.push(project);
+            }
+        }
+
+        Ok(projects)
+    }
+
+    fn projects_dir(&self) -> path::PathBuf {
+        path::Path::new(&self.base_path).join(PROJECTS_DIR)
+    }
+}

--- a/src/lib/backend-client.ts
+++ b/src/lib/backend-client.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/tauri';
+
+export interface Project {
+	name: string;
+}
+
+export async function list_projects(): Promise<Project[]> {
+	return await invoke('list_projects', {});
+}

--- a/src/lib/backend-client.ts
+++ b/src/lib/backend-client.ts
@@ -4,6 +4,6 @@ export interface Project {
 	name: string;
 }
 
-export async function list_projects(): Promise<Project[]> {
+export async function listProjects(): Promise<Project[]> {
 	return await invoke('list_projects', {});
 }


### PR DESCRIPTION
This PR adds:
- a `models.rs` file for the data model on the backend side
- a `operations.rs` file which contains code to list and create projects + initializing a folder to store all of that on the user's computer.
- a `list_projects` command to the Tauri app which can be invoked
- an `ApplicationState` to the Tauri app allowing to store things (such as a `ProjectManager`) for all commands to use.
- a fronted `backend.ts` file containing a `Project` interface, and a `list_projects` function which can be used to obtain a list of projects from the backend directly in the frontend 😉 