### PR TITLE
environments support

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,5 +1,6 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
-use serde::Serialize;
 
 // TestKind represents the kind of test we are dealing with
 // (e.g. a block test, a javascript test, etc.)
@@ -27,7 +28,7 @@ enum TestCollection {
     Test(Test),
 
     // A suite of tests
-    Suite(Vec<Test>)
+    Suite(Vec<Test>),
 }
 
 // A Project represents a collection of tests and suites
@@ -43,7 +44,6 @@ pub struct Project {
     // The (optional) description of the content
     // of the Project.
     pub description: Option<String>,
-
     // FIXME @oleiade: eventually, we want environment to be also definable
     // at the project level (and give it precedence) but for the hackathon
     // we start and stick with an app-wide "global" environment.
@@ -61,5 +61,42 @@ impl Project {
 
     pub fn default() -> Self {
         Self::new("default", None)
+    }
+}
+
+// Represents an Environment with its key/value variable pairs
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Environment {
+    name: String,
+    description: String,
+    variables: BTreeMap<String, String>,
+}
+
+impl Environment {
+    pub fn new(name: &str, description: &str, variables: BTreeMap<String, String>) -> Self {
+        Self {
+            name: name.to_string(),
+            description: description.to_string(),
+            variables,
+        }
+    }
+}
+
+// The environment data file, it includes the currently
+// active environment.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EnvironmentsData {
+    environments: Vec<Environment>,
+
+    // active environment name
+    pub active: String,
+}
+
+impl EnvironmentsData {
+    pub fn new(environments: Vec<Environment>, active: &str) -> Self {
+        Self {
+            environments,
+            active: active.to_string(),
+        }
     }
 }

--- a/src/lib/backend-client.ts
+++ b/src/lib/backend-client.ts
@@ -5,6 +5,18 @@ export interface Project {
   description?: string;
 }
 
+export interface Environment {
+  name: string;
+  description?: string;
+  variables: Record<string, string>;
+}
+
+export interface EnvironmentsData {
+  active: string;
+  environments: Array<Environment>;
+}
+
+
 /**
  * List all projects
  *
@@ -48,4 +60,14 @@ export function runScriptInCloud({
   projectId: string;
 }): Promise<string> {
   return invoke("run_script_in_cloud", { script, projectId });
+}
+
+// load environments from disk
+export async function loadEnvironments(): Promise<EnvironmentsData> {
+  return await invoke("load_environments", {});
+}
+
+// save environments to disk
+export async function saveEnvironments(environmentsData: EnvironmentsData): Promise<void> {
+  return await invoke("save_environments", { environmentsData });
 }

--- a/src/routes/Sidebar.svelte
+++ b/src/routes/Sidebar.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { PlusCircle, FlaskConical } from "lucide-svelte";
-  import { Check, ChevronsUpDown } from "lucide-svelte";
+  import { Check, ChevronsUpDown, Container } from "lucide-svelte";
   import { tick } from "svelte";
 
   import { goto } from "$app/navigation";
-  import { createProject } from "$lib/backend-client";
+  import { createProject, loadEnvironments, saveEnvironments } from "$lib/backend-client";
   import * as AlertDialog from "$lib/components/ui/alert-dialog";
   import { Badge } from "$lib/components/ui/badge";
   import * as Command from "$lib/components/ui/command";
@@ -37,6 +37,17 @@
     const createdProject = await createProject(createProjectValue);
     projects.update((p) => [...p, createdProject]);
     createProjectValue = "";
+  }
+
+  // TODO: remove
+  // Example usage of environments, load data from disk and
+  // overwrite it.
+  async function loadEnv() {
+    const envs = await loadEnvironments();
+    envs.active = "Bobby";
+    envs.environments[0].variables["blah"] = "2";
+    console.log(envs);
+    await saveEnvironments(envs);
   }
 </script>
 
@@ -92,6 +103,16 @@
   </Popover.Root>
 
   <Separator />
+
+  <Button variant="ghost" class="my-2" on:click={() => goto("/")}>
+    <FlaskConical class="mr-2 h-4 w-4" /> Go to tests
+  </Button>
+
+  <Separator />
+
+  <Button variant="ghost" class="my-2" on:click={loadEnv}>
+    <Container class="mr-2 h-4 w-4" /> Environments
+  </Button>
 </div>
 
 <AlertDialog.Root bind:open={showCreateDialog}>


### PR DESCRIPTION
Backend functionality for storing and retrieving `Environments` that have specific variables (key/value) pairs, as well as the active one.

It adds the frontend actions:
- `save_environments`
- `load_environments`

A button has been added to the UI that will load the environments from disk, change it, console.log it & save them back, this as an example of how to use the API.

They are saved as a single `environments.json` file with this format:
```json
{
  "environments": [
    {
      "name": "default",
      "description": "default environment",
      "variables": {
        "blah": "2"
      }
    }
  ],
  "active": "default"
}
```