### PR TITLE
fix drag not working sometimes

### DIFF
--- a/src/routes/test/edit/blocks/BlocksEditor.svelte
+++ b/src/routes/test/edit/blocks/BlocksEditor.svelte
@@ -2,7 +2,7 @@
   import * as Tabs from "$lib/components/ui/tabs";
   import type { BlockFile } from "$lib/stores/editor";
   import { onDestroy, onMount } from "svelte";
-  import Canvas from "../Canvas.svelte";
+  import Canvas from "./Canvas.svelte";
   import ScriptPreview from "./ScriptPreview.svelte";
   import { blockTest, loadBlockTest } from "$lib/stores/test";
   import { loadContent, storeContent } from "$lib/files";

--- a/src/routes/test/edit/blocks/Canvas.svelte
+++ b/src/routes/test/edit/blocks/Canvas.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import type { Block as BlockType } from "$lib/stores/test/types";
 
-  import Root from "./blocks/Root.svelte";
-  import { dropzone, type DroppedEvent } from "./blocks/primitives/dnd";
+  import Root from "./Root.svelte";
+  import { dropzone, type DroppedEvent } from "./primitives/dnd";
   import { reparentBlock, roots, selected } from "$lib/stores/test";
-  import AnyBlock from "./blocks/AnyBlock.svelte";
-  import Toolbox from "./blocks/Toolbox.svelte";
+  import AnyBlock from "./AnyBlock.svelte";
+  import Toolbox from "./Toolbox.svelte";
 
   const handleDrop = ({ detail }: CustomEvent<DroppedEvent<BlockType, {}>>) => {
     const dropped = detail.data.dropped;

--- a/src/routes/test/edit/blocks/Toolbox.svelte
+++ b/src/routes/test/edit/blocks/Toolbox.svelte
@@ -129,7 +129,7 @@
   }
 </script>
 
-<div class="toolbox flex flex-col" use:dropmask>
+<div class="toolbox absolute bottom-0 top-0 flex flex-col" use:dropmask>
   <div class="m-4 mr-6 flex flex-auto list-none flex-col rounded-md bg-slate-200 p-0 shadow-md">
     {#each CATEGORIES as category (category.id)}
       <h2 class="p-2 font-bold">{category.name}</h2>

--- a/src/routes/test/edit/blocks/primitives/Block.svelte
+++ b/src/routes/test/edit/blocks/primitives/Block.svelte
@@ -49,7 +49,7 @@
   id={block.id}
   use:draggable={{ type, data: block }}
   class={cn(
-    "block-root flex w-min items-center rounded-r-md outline-2 outline-indigo-500 focus:outline",
+    "block-root z-10 flex w-min items-center rounded-r-md outline-2 outline-indigo-500 focus:outline",
     className,
   )}
   class:dragging

--- a/src/routes/test/edit/blocks/primitives/Collection.svelte
+++ b/src/routes/test/edit/blocks/primitives/Collection.svelte
@@ -58,12 +58,12 @@
       <div class={cn("w-2 bg-white", className)}></div>
       <ul class="separator flex w-6 flex-auto list-none flex-col">
         {#each items as item (item.id)}
-          <li class="relative border-slate-200">
+          <li class="relative z-0 border-slate-200">
             <DropZone {accepts} data={item} on:dropped={handleDropped} />
             <slot {item} />
           </li>
         {/each}
-        <li class="relative min-h-2">
+        <li class="relative z-0 min-h-2">
           <DropZone {accepts} data={null} on:dropped={handleDropped} />
         </li>
       </ul>


### PR DESCRIPTION
Due to some layering issues the mouse events were being registered on an (visually) underlying element. Z-indexing to the recuse.