### PR TITLE
Add project's tests create/list/get operations

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -39,6 +39,9 @@ fn main() {
             get_cloud_token,
             load_environments,
             save_environments,
+            create_test,
+            list_tests,
+            get_test
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -94,10 +97,7 @@ async fn create_project(
 async fn load_environments(
     state: tauri::State<'_, ApplicationState>,
 ) -> Result<models::EnvironmentsData, String> {
-    state
-        .environment_manager
-        .load()
-        .map_err(|e| e.to_string())
+    state.environment_manager.load().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -108,6 +108,41 @@ async fn save_environments(
     state
         .environment_manager
         .save(&environments_data)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn create_test(
+    state: tauri::State<'_, ApplicationState>,
+    project_name: &str,
+    test: models::Test,
+) -> Result<models::Test, String> {
+    state
+        .project_manager
+        .create_test(project_name, test)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn list_tests(
+    state: tauri::State<'_, ApplicationState>,
+    project_name: &str,
+) -> Result<Vec<models::Test>, String> {
+    state
+        .project_manager
+        .list_tests(project_name)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn get_test(
+    state: tauri::State<'_, ApplicationState>,
+    project_name: &str,
+    test_name: &str,
+) -> Result<models::Test, String> {
+    state
+        .project_manager
+        .get_test(project_name, test_name)
         .map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,22 +1,72 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt::Display;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 // TestKind represents the kind of test we are dealing with
 // (e.g. a block test, a javascript test, etc.)
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum TestKind {
-    Block,
+    Blocks,
+    OpenAPI,
     Javascript,
+}
+
+impl Display for TestKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            TestKind::Blocks => "blocks".to_string(),
+            TestKind::OpenAPI => "openapi".to_string(),
+            TestKind::Javascript => "js".to_string(),
+        };
+        write!(f, "{}", str)
+    }
+}
+
+impl FromStr for TestKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "blocks" => Ok(TestKind::Blocks),
+            "openapi" => Ok(TestKind::OpenAPI),
+            "js" => Ok(TestKind::Javascript),
+            _ => Err(format!("{} is not a valid TestKind", s)),
+        }
+    }
 }
 
 // Test represents a single test that can be ran
 // either independently or as part of a suite.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Test {
-    kind: TestKind,
-    name: String,
-    file_path: PathBuf,
+    // Name of the test
+    pub name: String,
+
+    // The kind of test, e.g. block, javascript, OpenAPI, etc.
+    pub kind: TestKind,
+
+    // The content of the test
+    //
+    // This is the actual content of the test, as defined
+    // in the user-interface, either through blocks, openAPI,
+    // or javascript.
+    //
+    // This is stored as a string under the hood for convenience.
+    // The default value is "".
+    pub content: String,
+}
+
+impl Test {
+    pub fn new(name: &str, kind: TestKind, content: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            kind,
+            content: content.to_string(),
+            // file_path: PathBuf::new(),
+        }
+    }
 }
 
 // A Collection represents either a single test, or

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -16,7 +16,7 @@ pub enum TestKind {
 impl Display for TestKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
-            TestKind::Blocks => "blocks".to_string(),
+            TestKind::Blocks => "blocks6".to_string(),
             TestKind::OpenAPI => "openapi".to_string(),
             TestKind::Javascript => "js".to_string(),
         };
@@ -29,7 +29,7 @@ impl FromStr for TestKind {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "blocks" => Ok(TestKind::Blocks),
+            "blocks6" => Ok(TestKind::Blocks),
             "openapi" => Ok(TestKind::OpenAPI),
             "js" => Ok(TestKind::Javascript),
             _ => Err(format!("{} is not a valid TestKind", s)),

--- a/src/lib/backend-client.ts
+++ b/src/lib/backend-client.ts
@@ -1,10 +1,5 @@
 import { invoke } from "@tauri-apps/api/tauri";
 
-export interface Project {
-  name: string;
-  description?: string;
-}
-
 export interface Environment {
   name: string;
   description?: string;
@@ -16,6 +11,43 @@ export interface EnvironmentsData {
   environments: Array<Environment>;
 }
 
+// load environments from disk
+export async function loadEnvironments(): Promise<EnvironmentsData> {
+  return await invoke("load_environments", {});
+}
+
+// save environments to disk
+export async function saveEnvironments(environmentsData: EnvironmentsData): Promise<void> {
+  return await invoke("save_environments", { environmentsData });
+}
+
+export interface Project {
+  name: string;
+  description?: string;
+}
+
+export class Test {
+  // The name of the test as it should be displayed
+  // by the UI.
+  name: string;
+
+  // The kind of the test.
+  kind: TestKind;
+
+  // The content of the test serialized as a string.
+  content: string;
+
+  constructor(name: string, kind: TestKind, content: string) {
+    this.name = name;
+    this.kind = kind;
+    this.content = content;
+  }
+}
+
+// TestKind indicates the underlying type of a test's
+// content: serialized blocks, javascript or an
+// openapi specification.
+export type TestKind = "Blocks" | "Javascript" | "OpenAPI";
 
 /**
  * List all projects
@@ -40,12 +72,36 @@ export async function createProject(
   return await invoke("create_project", { name, description });
 }
 
-export async function getToken(): Promise<string> {
-  return await invoke("get_cloud_token", {});
+/**
+ * Create a new test as part of the seclect `projectName`.
+ *
+ * @param projectName The name of the parent project
+ * @param test The test to create
+ * @returns The created test
+ */
+export async function createTest(projectName: string, test: Test): Promise<Test> {
+  return await invoke("create_test", { projectName, test });
 }
 
-export async function saveToken(token: string): Promise<void> {
-  return await invoke("set_cloud_token", { token });
+/**
+ * List the tests for a project
+ *
+ * @param projectName The name of the parent project to list tests for
+ * @returns The list of tests for the project
+ */
+export async function listTests(projectName: string): Promise<Test[]> {
+  return await invoke("list_tests", { projectName });
+}
+
+/**
+ * Get a test by name
+ *
+ * @param projectName The name of the parent project
+ * @param testName The name of the test
+ * @returns The sought after test
+ */
+export async function getTest(projectName: string, testName: string): Promise<Test> {
+  return await invoke("get_test", { projectName, testName });
 }
 
 export function runScriptLocally(script: string): Promise<string> {
@@ -62,12 +118,10 @@ export function runScriptInCloud({
   return invoke("run_script_in_cloud", { script, projectId });
 }
 
-// load environments from disk
-export async function loadEnvironments(): Promise<EnvironmentsData> {
-  return await invoke("load_environments", {});
+export async function getToken(): Promise<string> {
+  return await invoke("get_cloud_token", {});
 }
 
-// save environments to disk
-export async function saveEnvironments(environmentsData: EnvironmentsData): Promise<void> {
-  return await invoke("save_environments", { environmentsData });
+export async function saveToken(token: string): Promise<void> {
+  return await invoke("set_cloud_token", { token });
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,21 +1,16 @@
-<script context="module">
-  import { setMode } from "mode-watcher";
-
-  setMode("light");
-</script>
-
-<script>
+<script lang="ts">
   import "../app.pcss";
   import { Toaster } from "$lib/components/ui/sonner";
+  import { ModeWatcher } from "mode-watcher";
+  import Sidebar from "./Sidebar.svelte";
   import { onMount } from "svelte";
 
   import { projects } from "$lib/stores/projects";
   import { listProjects } from "$lib/backend-client";
-  import Sidebar from "./Sidebar.svelte";
+  import TestToolbar from "./test/edit/TestToolbar.svelte";
 
   onMount(async () => {
     const projectsList = await listProjects();
-
     projects.update(() => projectsList);
   });
 </script>


### PR DESCRIPTION
This Pull Request adds:
- a `Test` type to both the tauri app, and the frontend
- a `create_test` operation
- a `list_test` operation
- a `get_test` operation

PS: I took a couple of shortcuts (it's a hackathon after all), such as storing the test's kind through the extension.