### PR TITLE
Add the save_test command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,7 +9,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
-use tauri::{Window, Manager};
+use tauri::{Manager, Window};
 
 use crate::operations::ProjectManager;
 
@@ -47,7 +47,8 @@ fn main() {
             save_environments,
             create_test,
             list_tests,
-            get_test
+            get_test,
+            save_test
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -56,16 +57,28 @@ fn main() {
 #[tauri::command]
 async fn close_splashscreen(window: Window) {
     // Close splashscreen
-    window.get_window("splashscreen").expect("no window labeled 'splashscreen' found").close().unwrap();
+    window
+        .get_window("splashscreen")
+        .expect("no window labeled 'splashscreen' found")
+        .close()
+        .unwrap();
 
     // Show main window
-    window.get_window("main").expect("no window labeled 'main' found").show().unwrap();
+    window
+        .get_window("main")
+        .expect("no window labeled 'main' found")
+        .show()
+        .unwrap();
 }
 
 #[tauri::command]
 async fn show_splashscreen(window: Window) {
     // Show splashscreen
-    window.get_window("splashscreen").expect("no window labeled 'splashscreen' found").show().unwrap();
+    window
+        .get_window("splashscreen")
+        .expect("no window labeled 'splashscreen' found")
+        .show()
+        .unwrap();
 }
 
 #[tauri::command]
@@ -175,6 +188,19 @@ async fn get_test(
     state
         .project_manager
         .get_test(project_name, test_name)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn save_test(
+    state: tauri::State<'_, ApplicationState>,
+    project_name: &str,
+    test_name: &str,
+    new_content: &str,
+) -> Result<(), String> {
+    state
+        .project_manager
+        .save_test(project_name, test_name, new_content)
         .map_err(|e| e.to_string())
 }
 

--- a/src/lib/backend-client.ts
+++ b/src/lib/backend-client.ts
@@ -104,6 +104,22 @@ export async function getTest(projectName: string, testName: string): Promise<Te
   return await invoke("get_test", { projectName, testName });
 }
 
+/**
+ * Save the test and updates its content with the new content as provided
+ * by the UI.
+ *
+ * @param projectName The name of the parent project
+ * @param testName The name of the test to save the content of
+ * @param newContent The new content of the test to save
+ */
+export async function saveTest(
+  projectName: string,
+  testName: string,
+  newContent: string,
+): Promise<void> {
+  return await invoke("save_test", { projectName, testName, newContent });
+}
+
 export function runScriptLocally(script: string): Promise<string> {
   return invoke("open_run_window", { script });
 }


### PR DESCRIPTION
This PR adds support for a `save_test` command. Note that I don't think this is the best design, but for the hackathon, it should do 👍🏻 